### PR TITLE
Add France Winter Timezone

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
 						  <option value="10">North America (UTC-7)</option>
 						  <option value="7">North America (UTC-4)</option>
 						  <option value="6">South America (UTC-3)</option>
+						  <option value="2">France (UTC+1/CET)</option>
 						  <option value="1">Europe (UTC+2)</option>
 						  <option value="-7">Oceania (UTC+10)</option>
 						  <option value="-6">East Asia (UTC+9)</option>

--- a/timers.html
+++ b/timers.html
@@ -86,6 +86,7 @@
 						  <option value="10">North America (UTC-7)</option>
 						  <option value="7">North America (UTC-4)</option>
 						  <option value="6">South America (UTC-3)</option>
+						  <option value="2">France (UTC+1/CET)</option>
 						  <option value="1">Europe (UTC+2)</option>
 						  <option value="-7">Oceania (UTC+10)</option>
 						  <option value="-6">East Asia (UTC+9)</option>


### PR DESCRIPTION
In France, we have 2 timezones depending on the part of the year we are in : 
This year it was : 
UTC+2 :  SUNDAY 27 MARCH 2022 3:00am - SUNDAY 30 OCTOBER 2:59am
UTC+1 (CET) : SUNDAY 30 OCTOBER 3:00am - SUNDAY 27 MARCH 2022 2:59am

I just added a France Timezone (CET) to cover this period.